### PR TITLE
added endpoint DELETE api/channel-members/id

### DIFF
--- a/src/server/api/controllers/channel-members.controller.js
+++ b/src/server/api/controllers/channel-members.controller.js
@@ -1,0 +1,11 @@
+const knex = require('../../config/db');
+
+const deleteChannelMember = async (channelMemberId) => {
+  return knex('channel_members')
+    .where({ id: channelMemberId })
+    .del();
+};
+
+module.exports = {
+  deleteChannelMember,
+};

--- a/src/server/api/routes/api-router.js
+++ b/src/server/api/routes/api-router.js
@@ -5,6 +5,8 @@ const router = express.Router();
 // Router imports
 const modulesRouter = require('./modules.router');
 
+const channelMembersRouter = require('./channel-members.router');
+
 const swaggerJsDoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
 
@@ -30,5 +32,7 @@ router.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Application routes
 router.use('/modules', modulesRouter);
+
+router.use('/channel-members', channelMembersRouter);
 
 module.exports = router;

--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -23,6 +23,8 @@ const channelMembersController = require('../controllers/channel-members.control
  *        description: channel member deleted
  *      5XX:
  *        description: Unexpected error.
+ *      404:
+ *        description: channel member ID doesn't exist.
  */
 router.delete('/:id', (req, res) => {
   channelMembersController

--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -40,8 +40,9 @@ router.delete('/:id', (req, res) => {
       }
     })
     .catch((error) => console.log(error));
+});
 
-/** 
+/**
  *@swagger
  * /channel-member/{ID}:
  *  get:

--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -1,0 +1,42 @@
+const express = require('express');
+
+const router = express.Router({ mergeParams: true });
+
+// controllers
+const channelMembersController = require('../controllers/channel-members.controller');
+
+/**
+ * @swagger
+ * /channel-members/{ID}:
+ *  delete:
+ *    summary: Delete a channel member
+ *    description:
+ *      Will delete a channel member with a given ID.
+ *    produces: application/json
+ *    parameters:
+ *      - in: path
+ *        name: ID
+ *        description: ID of the channel member to delete.
+ *    responses:
+ *      200:
+ *        description: channel member deleted
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.delete('/:id', (req, res) => {
+  channelMembersController
+    .deleteChannelMember(req.params.id, req)
+    .then((result) => {
+      // If result is equal to 0, then that means the channel member id does not exist
+      if (result === 0) {
+        res
+          .status(404)
+          .send('The channel member ID you provided does not exist.');
+      } else {
+        res.json({ success: true });
+      }
+    })
+    .catch((error) => console.log(error));
+});
+
+module.exports = router;


### PR DESCRIPTION
# Description

Please provide a short summary explaining what this PR is about.
This is the PR for deleting channel members

Fixes # (issue)
fixes issue 33
# How to test?

You can test it in postman with **`localhost:5000/api/channel-members/2`** where 2 is the channel member id, could be any id number as long as it exists in your DB.

Please provide a short summary how your changes can be tested?

# Checklist

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] This PR is ready to be merged and not breaking any other functionality
