### PR TITLE
created endpoint get api/channel-members/id

### DIFF
--- a/src/server/api/controllers/channel-members.controller.js
+++ b/src/server/api/controllers/channel-members.controller.js
@@ -1,0 +1,30 @@
+const knex = require('../../config/db');
+const Error = require('../lib/utils/http-error');
+
+const getChannelMemberById = async (id) => {
+  try {
+    const channelMemberById = await knex('channel_members')
+      .select(
+        'channel_members.fk_channel_id',
+        'user_name',
+        'profile_image',
+        'channel_members.created_at',
+        'last_seen',
+      )
+      .innerJoin('users', 'users.id', '=', 'channel_members.fk_user_id')
+      .where({ 'channel_members.fk_channel_id': id });
+    if (channelMemberById.length === 0) {
+      throw new Error(
+        `incorrect entry channel members with the id of ${id}`,
+        404,
+      );
+    }
+    return channelMemberById;
+  } catch (error) {
+    return error.message;
+  }
+};
+
+module.exports = {
+  getChannelMemberById,
+};

--- a/src/server/api/controllers/channel-members.controller.js
+++ b/src/server/api/controllers/channel-members.controller.js
@@ -38,5 +38,5 @@ const createChannelMember = async (body) => {
 
 module.exports = {
   createChannelMember,
-  getChannelMemberById
+  getChannelMemberById,
 };

--- a/src/server/api/routes/api-router.js
+++ b/src/server/api/routes/api-router.js
@@ -5,6 +5,8 @@ const router = express.Router();
 // Router imports
 const modulesRouter = require('./modules.router');
 
+const channelMembersRouter = require('./channel-members.router');
+
 const swaggerJsDoc = require('swagger-jsdoc');
 const swaggerUi = require('swagger-ui-express');
 
@@ -30,5 +32,7 @@ router.use('/documentation', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Application routes
 router.use('/modules', modulesRouter);
+
+router.use('/channel-members', channelMembersRouter);
 
 module.exports = router;

--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -33,7 +33,10 @@ router.get('/:id', (req, res, next) => {
     .getChannelMemberById(req.params.id)
     .then((result) => res.json(result))
     .catch(next);
+});
 
+/**
+ * @swagger
  * /channel-members:
  *  post:
  *    summary: Create channel-members

--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -1,0 +1,37 @@
+const express = require('express');
+
+const router = express.Router({ mergeParams: true });
+
+// controllers
+const channelMembersController = require('../controllers/channel-members.controller');
+
+/**
+ * @swagger
+ * /channel-member/{ID}:
+ *  get:
+ *    summary: Get channel members by ID
+ *    description:
+ *      Will return single channel member with a matching ID.
+ *    produces: application/json
+ *    parameters:
+ *     - in: path
+ *       name: ID
+ *       schema:
+ *         type: integer
+ *         required: true
+ *         description: The ID of the channel member to get
+ *
+ *    responses:
+ *      200:
+ *        description: Successful request
+ *      5XX:
+ *        description: Unexpected error.
+ */
+router.get('/:id', (req, res, next) => {
+  channelMembersController
+    .getChannelMemberById(req.params.id)
+    .then((result) => res.json(result))
+    .catch(next);
+});
+
+module.exports = router;


### PR DESCRIPTION
# Description

This PR is about getting channel members with the id of the channel.

Fixes # (issue)
fixes #34 
# How to test?

You can test in postman with **_localhost:5000/api/channel-members/2_**  where _2_ is the channel you want to get the channel members from. can be any other number as long as the channel exists.

# Checklist

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] This PR is ready to be merged and not breaking any other functionality
