### PR TITLE
fixed documentation for get channel-members/id

### DIFF
--- a/src/server/api/routes/channel-members.router.js
+++ b/src/server/api/routes/channel-members.router.js
@@ -91,7 +91,7 @@ router.delete('/:id', (req, res) => {
 
 /**
  *@swagger
- * /channel-member/{ID}:
+ * /channel-members/{ID}:
  *  get:
  *    summary: Get channel members by ID
  *    description:


### PR DESCRIPTION
# Description
This PR fixes the swagger documentation for get channel-members/id

Fixes # (issue)
N/A
# How to test?
You can test with swagger at **http://localhost:3000/api/documentation/#/default/get_channel_members__ID_**

# Checklist

- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] This PR is ready to be merged and not breaking any other functionality
