### PR TITLE
fixes message id on messages controler

### DIFF
--- a/src/server/api/controllers/messages-controller.js
+++ b/src/server/api/controllers/messages-controller.js
@@ -18,8 +18,15 @@ const getChannelMessages = async (req) => {
       );
     }
     if (channelId) {
-      channelMessages = channelMessages
-        .select('users.user_name as userName')
+      channelMessages = knex('channel_messages')
+        .select(
+          'users.user_name as userName',
+          'users.email',
+          'users.profile_image as profileImage',
+          'channel_messages.updated_at',
+          'channel_messages.id',
+          'channel_messages.message',
+        )
         .where('channel_messages.fk_channel_id', channelId)
         .join('users', {
           'channel_messages.fk_user_id': 'users.id',


### PR DESCRIPTION
# Description
fixes the response given by messages-controller, it was giving the user id instead message id

Fixes #321 

#How to test?
run "npm run dev" and console log "messages" to see the right response

# Checklist
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] This PR is ready to be merged and not breaking any other functionality
